### PR TITLE
Improve syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2970,6 +2970,12 @@
                 "brace-expansion": "^1.1.7"
             }
         },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
         "mississippi": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -3016,14 +3022,6 @@
             "dev": true,
             "requires": {
                 "minimist": "0.0.8"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.5",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-                    "dev": true
-                }
             }
         },
         "mocha": {

--- a/syntaxes/wikitext.tmLanguage.json
+++ b/syntaxes/wikitext.tmLanguage.json
@@ -115,25 +115,24 @@
                             "include": "$self"
                         },
                         {
-                            "name": "keyword.operator.wikitext",
-                            "match": "\\|"
-                        },
-                        {
-                            "match": "(?:\\s*)(?:([-\\w.]+)((:)))?([-\\w.:]+)\\s*(=)",
+                            "match": "(\\|)|(?:\\s*)(?:([-\\w.]+)((:)))?([-\\w.:]+)\\s*(=)",
                             "captures": {
                                 "1": {
-                                    "name": "entity.other.attribute-name.namespace.wikitext"
+                                    "name": "keyword.operator.wikitext"
                                 },
                                 "2": {
-                                    "name": "entity.other.attribute-name.wikitext"
+                                    "name": "entity.other.attribute-name.namespace.wikitext"
                                 },
                                 "3": {
-                                    "name": "punctuation.separator.namespace.wikitext"
+                                    "name": "entity.other.attribute-name.wikitext"
                                 },
                                 "4": {
-                                    "name": "entity.other.attribute-name.localname.wikitext"
+                                    "name": "punctuation.separator.namespace.wikitext"
                                 },
                                 "5": {
+                                    "name": "entity.other.attribute-name.localname.wikitext"
+                                },
+                                "6": {
                                     "name": "keyword.operator.equal.wikitext"
                                 },
                                 "": {
@@ -305,6 +304,17 @@
                     "patterns": [
                         {
                             "include": "$self"
+                        },
+                        {
+                            "match": "(\\|)|(?:\\s*)(?:([-\\w.]+)((:)))?([-\\w.:]+)\\s*(=)",
+                            "captures": {
+                                "1": {
+                                    "name": "keyword.operator.wikitext"
+                                },
+                                "5": {
+                                    "name": "entity.other.attribute-name.localname.wikitext"
+                                }
+                            }
                         }
                     ]
                 },

--- a/syntaxes/wikitext.tmLanguage.json
+++ b/syntaxes/wikitext.tmLanguage.json
@@ -778,12 +778,12 @@
             "patterns": [
                 {
                     "begin": "<%--",
+                    "end": "--%>",
+                    "name": "comment.block.xml",
                     "captures": {
                         "0": {
                             "name": "punctuation.definition.comment.xml"
-                        },
-                        "end": "--%>",
-                        "name": "comment.block.xml"
+                        }
                     }
                 },
                 {

--- a/syntaxes/wikitext.tmLanguage.json
+++ b/syntaxes/wikitext.tmLanguage.json
@@ -16,7 +16,7 @@
         "wikitext": {
             "patterns": [
                 {
-                    "include": "#argmuent"
+                    "include": "#argument"
                 },
                 {
                     "include": "#entity"
@@ -137,7 +137,7 @@
                                     "name": "keyword.operator.equal.wikitext"
                                 },
                                 "": {
-                                    "name": "keyword.operator.argunment.wikitext"
+                                    "name": "keyword.operator.argument.wikitext"
                                 }
                             }
                         }
@@ -159,7 +159,7 @@
                             },
                             "patterns": [
                                 {
-                                    "include": "#argmuent"
+                                    "include": "#argument"
                                 },
                                 {
                                     "include": "#comments"
@@ -216,7 +216,7 @@
                         }
                     ]
                 },
-                "argmuent": {
+                "argument": {
                     "name": "markup.heading",
                     "begin": "{{{",
                     "end": "}}}",

--- a/syntaxes/wikitext.tmLanguage.json
+++ b/syntaxes/wikitext.tmLanguage.json
@@ -115,7 +115,7 @@
                             "include": "$self"
                         },
                         {
-                            "match": "(\\|)|(?:\\s*)(?:([-\\w.]+)((:)))?([-\\w.:]+)\\s*(=)",
+                            "match": "(\\|)(?:\\s*)(?:([-\\w.]+)((:)))?([-\\w.:]+)\\s*(=)",
                             "captures": {
                                 "1": {
                                     "name": "keyword.operator.wikitext"
@@ -285,7 +285,7 @@
                 },
                 "internalLink": {
                     "name": "string.quoted.wikitext",
-                    "begin": "(\\[\\[)(([\\w\\-\\s\\(\\)\\.]*:)*)?([#\\w\\-\\s\\(\\)\\.]*(\\|))?",
+                    "begin": "(\\[\\[)(([\\w\\-\\s\\(\\)\\.]*:)*)?([#\\w\\-\\s\\(\\)\\.]*)?",
                     "end": "(\\]\\])",
                     "captures": {
                         "1": {
@@ -296,9 +296,6 @@
                         },
                         "4": {
                             "name": "entity.other.attribute-name.wikitext"
-                        },
-                        "5": {
-                            "name": "keyword.operator.wikitext"
                         }
                     },
                     "patterns": [


### PR DESCRIPTION
- Fix some typos ("argument")
- Add keyword.operator ("|" sign) and attribute name to internal link. For example `[[File:Image.jpg|thumb|alt=blah blah|caption blah blah]]`
- Fix capturing rule for attribute name in template. Before, if the argument is a URL with an equal sign in it (e.g. 'url=http://example.com/id=1') then the word preceding the equal sign will be matched as attribute name (e.g. 'id')