### PR TITLE
Highlight self-closing nowiki tag. For #43

### DIFF
--- a/syntaxes/wikitext.tmLanguage.yaml
+++ b/syntaxes/wikitext.tmLanguage.yaml
@@ -426,15 +426,15 @@ repository:
                     name: keyword.operator.wikitext
       wikixml:
         patterns:
-          - include: "#nowiki"
           - include: "#wikitag"
+          - include: "#nowiki"
           - include: "#ref"
           - include: "#jsonin"
           - include: "#math"
         repository:
           nowiki:
             contentName: meta.embedded.block.plaintext
-            begin: (?i)(<)(nowiki)(\s+[^>\/]+)?\s*(>)
+            begin: (?i)(<)(nowiki)(\s+[^>]+)?\s*(>)
             #          1<12nowiki2    3a="a"34>4
             beginCaptures:
               0:

--- a/syntaxes/wikitext.tmLanguage.yaml
+++ b/syntaxes/wikitext.tmLanguage.yaml
@@ -434,7 +434,7 @@ repository:
         repository:
           nowiki:
             contentName: meta.embedded.block.plaintext
-            begin: (?i)(<)(nowiki)(\s+[^>]+)?\s*(>)
+            begin: (?i)(<)(nowiki)(\s+[^>\/]+)?\s*(>)
             #          1<12nowiki2    3a="a"34>4
             beginCaptures:
               0:
@@ -465,7 +465,7 @@ repository:
               3:
                 name: punctuation.definition.tag.end.wikitext
           wikitag:
-            match: (?i)(<)(templatestyles|ref)(\s+[^>]+)?\s*(/>)
+            match: (?i)(<)(templatestyles|ref|nowiki)(\s+[^>]+)?\s*(/>)
             #          1<12templatestyles23  h=here3    4/>4
             captures:
               1:


### PR DESCRIPTION
- Not matching `<nowiki` if there is a forward slash so `<nowiki />` is not treated like `<nowiki>`.
- Allowing wikitag to match nowiki so `<nowiki />` is highlighted.

**Rationale:**
- Self-closing nowiki tags are permissible [according to MediaWiki](https://www.mediawiki.org/wiki/Help:Formatting#Nowiki_for_HTML).
- Self-closing nowiki tags are highlighted by other syntax highlighters for Wikitext e.g. [CodeMirror](https://www.mediawiki.org/wiki/Extension:CodeMirror), which is used on [multiple online editors](https://help.fandom.com/wiki/Extension:CodeMirror).

**Before:**
![image](https://user-images.githubusercontent.com/709117/145483746-ba9299ee-c903-49a4-96ad-167b092f7218.png)**After**
![image](https://user-images.githubusercontent.com/709117/145483572-a13f37f2-2fc2-4337-b8ad-beceafef1ee2.png)
