### PR TITLE
Add Scribunto to lua mapping

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,6 +26,7 @@
         "luxon",
         "mimetypes",
         "mwbot",
+        "Scribunto",
         "vsix",
         "wikixml",
         "Xvfb"

--- a/src/export_command/wikimedia_function/page.ts
+++ b/src/export_command/wikimedia_function/page.ts
@@ -210,7 +210,7 @@ export async function getPageCode(args: Record<string, string>, tBot: MWBot): Pr
         }
     }
     function getInfoHead(info: Record<PageInfo, string | undefined>): string {
-        const commentList: Record<string, [string, string]> = {
+        const commentList: Record<string, [string, string] | undefined> = {
             wikitext: ["", ""],
             jsonc: ["/*", "*/"],
             lua: ["--[=[", "--]=]"],
@@ -219,6 +219,7 @@ export async function getPageCode(args: Record<string, string>, tBot: MWBot): Pr
             php: ["/*", "*/"],
             // 'flow-board': ["/*", "*/"],
             // 'sanitized-css': ["/*", "*/"],
+            // 'Scribunto' : ["--[=[", "--]=]"],
         };
         const headInfo: Record<string, string | undefined> = {
             comment: "Please do not remove this struct. It's record contains some important information of edit. This struct will be removed automatically after you push edits.",
@@ -227,8 +228,12 @@ export async function getPageCode(args: Record<string, string>, tBot: MWBot): Pr
         const infoLine: string = Object.keys(headInfo).
             map((key: string) => `    ${key} = #${headInfo[key] ?? ''}#`).
             join("\r");
-        console.log(info?.['contentModel']);
-        return commentList[modelNameToLanguage(info?.['contentModel'])].join(`<%-- [PAGE_INFO]
+        console.log(info?.contentModel);
+        const comment: [string, string] | undefined = commentList[modelNameToLanguage(info?.contentModel)]
+        if (comment === undefined) {
+            throw new Error(`Unsupported content model: ${info?.contentModel}. Please report this issue to the author of this extension.`);
+        }
+        return comment.join(`<%-- [PAGE_INFO]
 ${infoLine}
 [END_PAGE_INFO] --%>`);
     }

--- a/src/export_command/wikimedia_function/page.ts
+++ b/src/export_command/wikimedia_function/page.ts
@@ -229,7 +229,7 @@ export async function getPageCode(args: Record<string, string>, tBot: MWBot): Pr
             map((key: string) => `    ${key} = #${headInfo[key] ?? ''}#`).
             join("\r");
         console.log(info?.contentModel);
-        const comment: [string, string] | undefined = commentList[modelNameToLanguage(info?.contentModel)]
+        const comment: [string, string] | undefined = commentList[modelNameToLanguage(info?.contentModel)];
         if (comment === undefined) {
             throw new Error(`Unsupported content model: ${info?.contentModel}. Please report this issue to the author of this extension.`);
         }

--- a/src/export_command/wikimedia_function/page.ts
+++ b/src/export_command/wikimedia_function/page.ts
@@ -203,6 +203,8 @@ export async function getPageCode(args: Record<string, string>, tBot: MWBot): Pr
                 return 'jsonc';
             case 'sanitized-css':
                 return 'css';
+            case 'Scribunto':
+                return 'lua';
             default:
                 return modelName;
         }


### PR DESCRIPTION
This fixes issue #62
The content model of a Scribunto module is `"Scribunto"`, and because that entry doesn't exist in `commentList` the result is `undefined.join` throwing an error.
https://github.com/Frederisk/Wikitext-VSCode-Extension/blob/04a6c0c11b867f7235e4eeb16e27eb9c38b4b09a/src/export_command/wikimedia_function/page.ts#L198-L232