### PR TITLE
Add an apostrophe to surrounding pairs

### DIFF
--- a/language-configuration.yaml
+++ b/language-configuration.yaml
@@ -100,6 +100,8 @@ surroundingPairs:
     - "-->"
   - - <
     - ">"
+  - - '
+    - "'"
 folding:
   markers:
     start: ^\s*<!--\s*#region\b.*-->


### PR DESCRIPTION
Adding an apostrophe (```'```) to surrounding pairs makes text formatting more convenient.