### PR TITLE
Improve "no host" error message; fix several typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,7 +145,7 @@ All notable changes to the "Wikitext" extension will be documented in this file.
 ### Added
 
 - Table caption syntax.
-- `<ref>` tag synax.
+- `<ref>` tag syntax.
 
 ### Changed
 
@@ -452,7 +452,7 @@ All notable changes to the "Wikitext" extension will be documented in this file.
 
 ### Added
 
-- Special support for chinese charcters.
+- Special support for chinese characters.
 
 ## [0.4.0]\* - 2020-02-02
 

--- a/src/export_command/vscode_function/host.ts
+++ b/src/export_command/vscode_function/host.ts
@@ -12,8 +12,8 @@ export async function getHost(): Promise<string | undefined> {
     if (host) { return host; }
     // else ask to edit
     const selection: string | undefined = await vscode.window.showWarningMessage(
-        `No Host Be Defined!
-You haven't defined the host of previewer yet, please input host value in the dialog box (or in settings) and try again.`
+        `No host defined!
+You haven't defined the host for the previewer yet; please input a host value in the dialog box (or in settings) and try again.`
         , "Edit", "Cancel");
     // edit
     if (selection === 'Edit') {

--- a/src/export_command/wikimedia_function/view.ts
+++ b/src/export_command/wikimedia_function/view.ts
@@ -87,7 +87,7 @@ export function getPreviewFactory(extension: vscode.ExtensionContext) {
 
         // if no panel, create one
         if (!previewCurrentPanel) {
-            // if have not, try to creat new one.
+            // if there is no panel, try to create new one.
             previewCurrentPanel = vscode.window.createWebviewPanel(
                 "previewer", viewerTitle, vscode.ViewColumn.Beside, {
                 enableScripts: config.get("enableJavascript"),

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
         // The path to test runner
         // Passed to --extensionTestsPath
         const extensionTestsPath = path.resolve(__dirname, './suite/index-node');
-        console.log("Runing test.");
+        console.log("Running test.");
         // Download VS Code, unzip it and run the integration test
         await runTests({
             extensionDevelopmentPath,

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -70,19 +70,19 @@ suite('WikimediaFunction Core TestSuite', () => {
 
         // Assert
         // hasInfo
-        assert.strictEqual(hasInfo.content, content, "hasInfo content faild");
+        assert.strictEqual(hasInfo.content, content, "hasInfo content failed");
         assert.deepStrictEqual(hasInfo.info, {
             pageTitle: pageTitle,
             pageID: "1",
             revisionID: undefined,
             contentFormat: undefined,
             contentModel: undefined
-        }, "hasInfo info faild");
+        }, "hasInfo info failed");
         // noInfo
-        assert.strictEqual(noInfo.content, content, "noInfo content faild");
-        assert.deepStrictEqual(noInfo.info, undefined, "noInfo info faild");
+        assert.strictEqual(noInfo.content, content, "noInfo content failed");
+        assert.deepStrictEqual(noInfo.info, undefined, "noInfo info failed");
         // mutiInfo
-        assert.notStrictEqual(mutiInfo.info, undefined, "mutiInfo info faild");
+        assert.notStrictEqual(mutiInfo.info, undefined, "mutiInfo info failed");
     });
 });
 
@@ -156,16 +156,16 @@ suite('CiteFunction Web TestSuite', () => {
 
         // Assert
         // title
-        assert.strictEqual(tOnlyContentStr, content + content, "title only content faild");
-        assert.strictEqual(tOnlyTagStr, content + content, "title only tag faild");
-        assert.strictEqual(tOnlyArgStr, content + title + content, "title only arg faild");
-        assert.strictEqual(tBothInStr, content + title + content, "title both in faild");
-        assert.strictEqual(tBothOutStr, content + content + title, "title both out faild");
+        assert.strictEqual(tOnlyContentStr, content + content, "title only content failed");
+        assert.strictEqual(tOnlyTagStr, content + content, "title only tag failed");
+        assert.strictEqual(tOnlyArgStr, content + title + content, "title only arg failed");
+        assert.strictEqual(tBothInStr, content + title + content, "title both in failed");
+        assert.strictEqual(tBothOutStr, content + content + title, "title both out failed");
         // notitle
-        assert.strictEqual(nOnlyContentStr, content + content, "no only content faild");
-        assert.strictEqual(nOnlyTagStr, content, "no only tag faild");
-        assert.strictEqual(nOnlyArgStr, content + content, "no only arg faild");
+        assert.strictEqual(nOnlyContentStr, content + content, "no only content failed");
+        assert.strictEqual(nOnlyTagStr, content, "no only tag failed");
+        assert.strictEqual(nOnlyArgStr, content + content, "no only arg failed");
         assert.strictEqual(nBothInStr, "", "no both in falid");
-        assert.strictEqual(nBothOutStr, content, "no both out faild");
+        assert.strictEqual(nBothOutStr, content, "no both out failed");
     });
 });


### PR DESCRIPTION
Changed the "no host" error message from:

> **No Host Be Defined!**
>
> You haven't defined the host of previewer yet, please input host value in the dialog box (or in settings) and try again.

to:

> **No host defined!**
>
> You haven't defined the host for the previewer yet; please input a host value in the dialog box (or in settings) and try again.

Also, fixed various typos in code and comments.
