### PR TITLE
Fix `invalidjson` error for `Wikitext: Get preview` (and other commands)

### DIFF
--- a/src/export_command/wikimedia_function/bot.ts
+++ b/src/export_command/wikimedia_function/bot.ts
@@ -131,7 +131,7 @@ export async function compareVersion(tBot: MWBot, major: number, minor: number, 
         meta: Meta.siteInfo,
     };
 
-    const result: unknown = await tBot.request(args, { method: 'GET' });
+    const result: unknown = await tBot.request(args);
     const re: any = result as any;
     // TODO: cast
 

--- a/src/export_command/wikimedia_function/page.ts
+++ b/src/export_command/wikimedia_function/page.ts
@@ -31,7 +31,7 @@ export function postPageFactory() {
                     meta: 'tokens',
                     type: 'csrf'
                 };
-                const result: unknown = await bot.request(args, { method: 'GET' });
+                const result: unknown = await bot.request(args);
                 const reNew: TokensResult = TokensConvert.toResult(result);
                 const token: string | undefined = reNew.query?.tokens?.csrftoken;
                 if (token) {
@@ -47,7 +47,7 @@ export function postPageFactory() {
                         action: "tokens",
                         type: "edit"
                     };
-                    const result: unknown = await bot.request(args, { method: 'GET' });
+                    const result: unknown = await bot.request(args);
                     const reOld: OldTokensResult = OldTokensConvert.toResult(result);
                     const token: string | undefined = reOld.tokens?.edittoken;
                     if (token) {
@@ -253,7 +253,7 @@ ${infoLine}
     const barMessage: vscode.Disposable = vscode.window.setStatusBarMessage("Wikitext: Getting code...");
     try {
         // get request result
-        const result: unknown = await tBot.request(args, { method: 'GET' });
+        const result: unknown = await tBot.request(args);
         // console.log(result);
         // Convert result as class
         const re: ReadPageResult = ReadPageConvert.toResult(result);
@@ -361,7 +361,7 @@ async function getValidTagList(tBot: MWBot): Promise<(number | string)[]> {
 
     const tagList: (number | string)[] = [];
     for (; ;) {
-        const result: unknown = await tBot.request(args, { method: 'GET' });
+        const result: unknown = await tBot.request(args);
         const re: TagsResult = TagsConvert.toResult(result);
 
         tagList.push(

--- a/src/export_command/wikimedia_function/view.ts
+++ b/src/export_command/wikimedia_function/view.ts
@@ -116,7 +116,7 @@ export async function showViewer(currentPanel: vscode.WebviewPanel | string, vie
 
     const barMessage: vscode.Disposable = vscode.window.setStatusBarMessage("Wikitext: Getting view...");
     try {
-        const result: unknown = await tBot.request(args, { method: 'GET' });
+        const result: unknown = await tBot.request(args);
         const re: GetViewResult = ViewConvert.toResult(result);
         if (!re.parse) { return undefined; }
 


### PR DESCRIPTION
## Summary

`Wikitext: Get preview` throws `invalidjson: No valid JSON response` for any non-trivial wikitext document since v4.0.3. This PR fixes it by removing the `{ method: 'GET' }` override at all six call sites so mwbot's default `POST` is used.

## Reproduction

1. Install the extension with default settings (`wikitext.host = "en.wikipedia.org"`).
2. Open any moderately large `.wikitext` file (≥ ~8 KB).
3. Run `Wikitext: Get preview` (Shift+Cmd/Ctrl+V).
4. Error notification: `invalidjson: No valid JSON response`.

## Root cause

`mwbot.request(args, options)` puts `args` into the POST `form` body. When `options.method` is overridden to `'GET'`, the underlying request library drops the form data — `form` is POST-only. The actual HTTP request becomes `GET /w/api.php?format=json` with no `action` parameter. MediaWiki responds with the API help page as **HTML** (`Content-Type: text/html`), mwbot then checks `typeof body !== 'object'` and throws `invalidjson: No valid JSON response`.

The `{ method: 'GET' }` overrides were introduced in v4.0.3 (changelog: "Used explicit request methods to access the API to avoid some potential issues").

## Why `mwbot-patch.ts` doesn't save the preview

`src/mwbot-patch.ts` correctly intercepts GET-method calls and moves `params` into `qs`. That works for small read-only queries — `siteinfo`, `tokens`, `csrf`, tag enumeration, `readPage` lookups. It **cannot** work for `action=parse` with a `text` parameter, because the request URL ends up containing the entire user document and exceeds the server's URI length limit.

Verified against `en.wikipedia.org`:

```console
$ # 4 KB wikitext via GET
$ curl -s -o /dev/null -w "%{http_code} %{content_type}\n" \
    -G "https://en.wikipedia.org/w/api.php" \
    --data-urlencode "format=json" --data-urlencode "action=parse" \
    --data-urlencode "text@4kb.txt" --data-urlencode "contentmodel=wikitext"
200 application/json; charset=utf-8

$ # 8 KB wikitext via GET
$ curl -s -o /dev/null -w "%{http_code} %{content_type}\n" \
    -G "https://en.wikipedia.org/w/api.php" \
    --data-urlencode "format=json" --data-urlencode "action=parse" \
    --data-urlencode "text@8kb.txt" --data-urlencode "contentmodel=wikitext"
414 text/html; charset=iso-8859-1   # Request-URI Too Long

$ # 8 KB wikitext via POST
$ curl -s -o /dev/null -w "%{http_code} %{content_type}\n" \
    -X POST "https://en.wikipedia.org/w/api.php?format=json" \
    --data-urlencode "action=parse" --data-urlencode "text@8kb.txt" \
    --data-urlencode "contentmodel=wikitext"
200 application/json; charset=utf-8
```

The reproduction document I hit this with was 34 KB — far past the limit.

## The fix

Drop the `{ method: 'GET' }` overrides at all six call sites. mwbot's default `POST` works for every MediaWiki API action regardless of payload size, and is what mwbot's defaults (`form: {}`, `qs: { format: 'json' }`, `json: true`) are designed around.

Files touched:

- `src/export_command/wikimedia_function/view.ts` — `showViewer` (preview / page view). **This is the one that surfaces as the user-visible bug.**
- `src/export_command/wikimedia_function/bot.ts` — `compareVersion` (siteinfo).
- `src/export_command/wikimedia_function/page.ts` — `postPage` csrf/edit token fetches, `pullPage`, `getValidTagList`.

The two `{ method: 'POST' }` call sites are untouched.

## Possible follow-up (not in this PR)

With this change, no caller passes `method: 'GET'` to `MWBot.prototype.request`. That means `src/mwbot-patch.ts` becomes dead code and its two imports in `extension-{node,web}.ts` can be removed. I left that out to keep the diff minimal; happy to add it (or do a separate PR) if you'd prefer.

## Test plan

- [x] Verified by removing `,{method:"GET"}` in the installed v4.0.4 bundle locally — preview works for a 34 KB document.
- [x] Verified the API-layer change with `curl` against `en.wikipedia.org` (POST returns valid JSON for any size; GET 414s past ~8 KB).
- [ ] CI typecheck (signature is `request(params: object, customRequestOptions?: RequestOptions)` — second arg already optional).

## Environment encountered on

- Extension: `RoweWilsonFrederiskHolme.wikitext` 4.0.4
- VSCode: 1.121.0
- OS: macOS (Darwin 25.4.0)
- Wiki host: `en.wikipedia.org` (default)