### PR TITLE
feat: support JSON content model pages

### DIFF
--- a/src/export_command/wikimedia_function/page.ts
+++ b/src/export_command/wikimedia_function/page.ts
@@ -212,6 +212,7 @@ export async function getPageCode(args: Record<string, string>, tBot: MWBot): Pr
             case undefined:
                 return 'wikitext';
             case 'flow-board':
+            case 'json':
                 return 'jsonc';
             case 'sanitized-css':
                 return 'css';

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -62,11 +62,21 @@ suite('WikimediaFunction Core TestSuite', () => {
         [END_PAGE_INFO] --%>
         {{Soft redirect|User:Роу Уилсон Фредериск Холм}}
         <!--{{produceEncouragement|count=1}}-->{{patrol}}`;
+        const jsonStr = `/*<%-- [PAGE_INFO]
+        Comment=#Please do not remove this struct.#
+        PageTitle=#MediaWiki:Test.json#
+        PageID=#123#
+        RevisionID=#456#
+        ContentModel=#json#
+        ContentFormat=#application/json#
+        [END_PAGE_INFO] --%>*/
+        {"foo": "bar"}`;
 
         // Act
         const hasInfo = getContentInfo(hasStr);
         const noInfo = getContentInfo(noStr);
         const mutiInfo = getContentInfo(mutiStr);
+        const jsonInfo = getContentInfo(jsonStr);
 
         // Assert
         // hasInfo
@@ -83,6 +93,10 @@ suite('WikimediaFunction Core TestSuite', () => {
         assert.deepStrictEqual(noInfo.info, undefined, "noInfo info failed");
         // mutiInfo
         assert.notStrictEqual(mutiInfo.info, undefined, "mutiInfo info failed");
+        // jsonInfo
+        assert.strictEqual(jsonInfo.content, `{"foo": "bar"}`, "jsonInfo content failed");
+        assert.strictEqual(jsonInfo.info?.contentModel, "json", "jsonInfo contentModel failed");
+        assert.strictEqual(jsonInfo.info?.contentFormat, "application/json", "jsonInfo contentFormat failed");
     });
 });
 


### PR DESCRIPTION
Fixes pulling pages whose content model is \json\ (e.g. \MediaWiki:*.json\).

## Problem
When pulling a page with content model \json\, \getPageCode\ mapped it to the \json\ language, but \commentList\ had no \json\ entry, so \getInfoHead\ threw \Unsupported content model: json\ and the page could not be opened.

## Change
- In \modelNameToLanguage\, map the \json\ content model to the \jsonc\ language (same highlighting as JSON, and the \[PAGE_INFO]\ comment header is valid there), matching the existing handling of \low-board\.
- Added a unit test covering round-tripping a JSON page header through \getContentInfo\.

## Verification
- \
pm run compile\ passes (only a pre-existing webpack warning).
- Unit tests pass (4 passing, including the new JSON case).